### PR TITLE
Fix typo in init script comment

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -13,7 +13,7 @@ const path = require("path");
 
 async function loadProgram(provider) {
     try {
-        // если программa есть в workspace (anchor test/dev)
+        // если программа есть в workspace (anchor test/dev)
         const p = anchor.workspace.SolLottery;
         if (p) return p;
     } catch {}


### PR DESCRIPTION
## Summary
- fix Russian word in `scripts/init.js` comment

## Testing
- `npm test` (missing script)
- `cargo test` (compilation produced warnings; interrupted)

------
https://chatgpt.com/codex/tasks/task_e_689f4dbd890083268786f965782620b7