### PR TITLE
Separate vault and staking authorities

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -1,8 +1,8 @@
 // scripts/init.js
 // Инициализация пула (initialize) под Token-2022
 // usage:
-// ANCHOR_PROVIDER_URL=https://api.devnet.solana.com \
-// ANCHOR_WALLET=~/.config/solana/id.json \
+// ANCHOR_PROVIDER_URL=https://api.devnet.solana.com \\
+// ANCHOR_WALLET=~/.config/solana/id.json \\
 // node scripts/init.js target/pool_state.json <MINT_2022_PUBKEY> [intervalSec=604800]
 
 const anchor = require("@coral-xyz/anchor");
@@ -13,7 +13,7 @@ const path = require("path");
 
 async function loadProgram(provider) {
   try {
-    // если программa есть в workspace (anchor test/dev)
+    // если программа есть в workspace (anchor test/dev)
     const p = anchor.workspace.SolLottery;
     if (p) return p;
   } catch {}

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -12,84 +12,89 @@ const fs = require("fs");
 const path = require("path");
 
 async function loadProgram(provider) {
-    try {
-        // если программa есть в workspace (anchor test/dev)
-        const p = anchor.workspace.SolLottery;
-        if (p) return p;
-    } catch {}
-    // иначе берём IDL из target/idl
-    const idlPath = path.resolve("target/idl/sol_lottery.json");
-    const idl = JSON.parse(fs.readFileSync(idlPath, "utf8"));
-    const programId = new PublicKey(idl.metadata?.address || process.env.PROGRAM_ID);
-    if (!programId) throw new Error("No programId: set idl.metadata.address or PROGRAM_ID env");
-    return new anchor.Program(idl, programId, provider);
+  try {
+    // если программa есть в workspace (anchor test/dev)
+    const p = anchor.workspace.SolLottery;
+    if (p) return p;
+  } catch {}
+  // иначе берём IDL из target/idl
+  const idlPath = path.resolve("target/idl/sol_lottery.json");
+  const idl = JSON.parse(fs.readFileSync(idlPath, "utf8"));
+  const programId = new PublicKey(
+    idl.metadata?.address || process.env.PROGRAM_ID
+  );
+  if (!programId)
+    throw new Error("No programId: set idl.metadata.address or PROGRAM_ID env");
+  return new anchor.Program(idl, programId, provider);
 }
 
 (async () => {
-    try {
-        const [, , poolKeypairPath, mintStr, intervalStr] = process.argv;
-        if (!poolKeypairPath || !mintStr) {
-            console.log("usage: node scripts/init.js target/pool_state.json <MINT_2022_PUBKEY> [intervalSec]");
-            process.exit(1);
-        }
-        const interval = intervalStr ? Number(intervalStr) : 604800; // неделя по умолчанию
-
-        const provider = anchor.AnchorProvider.env();
-        anchor.setProvider(provider);
-        const program = await loadProgram(provider);
-
-        const poolKeypair = Keypair.fromSecretKey(
-            Uint8Array.from(require(path.resolve(poolKeypairPath)))
-        );
-        const poolStatePk = poolKeypair.publicKey;
-        const mint = new PublicKey(mintStr);
-
-        // PDAs (совпадают с seeds в контракте)
-        const [vaultAuthority] = PublicKey.findProgramAddressSync(
-            [Buffer.from("vault"), poolStatePk.toBuffer()],
-            program.programId
-        );
-        const [vaultTokenAccount] = PublicKey.findProgramAddressSync(
-            [Buffer.from("vault"), poolStatePk.toBuffer()],
-            program.programId
-        );
-        const [stakingAuthority] = PublicKey.findProgramAddressSync(
-            [Buffer.from("staking"), poolStatePk.toBuffer()],
-            program.programId
-        );
-        const [stakingTokenAccount] = PublicKey.findProgramAddressSync(
-            [Buffer.from("staking"), poolStatePk.toBuffer()],
-            program.programId
-        );
-
-        console.log("Program:              ", program.programId.toBase58());
-        console.log("PoolState:            ", poolStatePk.toBase58());
-        console.log("Mint (Token-2022):    ", mint.toBase58());
-        console.log("VaultTokenAccount PDA:", vaultTokenAccount.toBase58());
-        console.log("StakingTokenAccount:  ", stakingTokenAccount.toBase58());
-        console.log("Interval (sec):       ", interval);
-
-        const sig = await program.methods
-            .initialize(new anchor.BN(interval))
-            .accounts({
-                poolState: poolStatePk,
-                mint,
-                vaultTokenAccount,
-                vaultAuthority,
-                stakingTokenAccount,
-                stakingAuthority,
-                owner: provider.wallet.publicKey,
-                systemProgram: SystemProgram.programId,
-                tokenProgram: TOKEN_2022_PROGRAM_ID, // <— ВАЖНО
-                rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-            })
-            .signers([poolKeypair])
-            .rpc();
-
-        console.log("initialize tx:", sig);
-    } catch (e) {
-        console.error("INIT ERROR:", e.message);
-        console.error(e);
-        process.exit(1);
+  try {
+    const [, , poolKeypairPath, mintStr, intervalStr] = process.argv;
+    if (!poolKeypairPath || !mintStr) {
+      console.log(
+        "usage: node scripts/init.js target/pool_state.json <MINT_2022_PUBKEY> [intervalSec]"
+      );
+      process.exit(1);
     }
+    const interval = intervalStr ? Number(intervalStr) : 604800; // неделя по умолчанию
+
+    const provider = anchor.AnchorProvider.env();
+    anchor.setProvider(provider);
+    const program = await loadProgram(provider);
+
+    const poolKeypair = Keypair.fromSecretKey(
+      Uint8Array.from(require(path.resolve(poolKeypairPath)))
+    );
+    const poolStatePk = poolKeypair.publicKey;
+    const mint = new PublicKey(mintStr);
+
+    // PDAs (совпадают с seeds в контракте)
+    const [vaultAuthority] = PublicKey.findProgramAddressSync(
+      [Buffer.from("vault-auth"), poolStatePk.toBuffer()],
+      program.programId
+    );
+    const [vaultTokenAccount] = PublicKey.findProgramAddressSync(
+      [Buffer.from("vault"), poolStatePk.toBuffer()],
+      program.programId
+    );
+    const [stakingAuthority] = PublicKey.findProgramAddressSync(
+      [Buffer.from("staking-auth"), poolStatePk.toBuffer()],
+      program.programId
+    );
+    const [stakingTokenAccount] = PublicKey.findProgramAddressSync(
+      [Buffer.from("staking"), poolStatePk.toBuffer()],
+      program.programId
+    );
+
+    console.log("Program:              ", program.programId.toBase58());
+    console.log("PoolState:            ", poolStatePk.toBase58());
+    console.log("Mint (Token-2022):    ", mint.toBase58());
+    console.log("VaultTokenAccount PDA:", vaultTokenAccount.toBase58());
+    console.log("StakingTokenAccount:  ", stakingTokenAccount.toBase58());
+    console.log("Interval (sec):       ", interval);
+
+    const sig = await program.methods
+      .initialize(new anchor.BN(interval))
+      .accounts({
+        poolState: poolStatePk,
+        mint,
+        vaultTokenAccount,
+        vaultAuthority,
+        stakingTokenAccount,
+        stakingAuthority,
+        owner: provider.wallet.publicKey,
+        systemProgram: SystemProgram.programId,
+        tokenProgram: TOKEN_2022_PROGRAM_ID, // <— ВАЖНО
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      })
+      .signers([poolKeypair])
+      .rpc();
+
+    console.log("initialize tx:", sig);
+  } catch (e) {
+    console.error("INIT ERROR:", e.message);
+    console.error(e);
+    process.exit(1);
+  }
 })();

--- a/scripts/lottery_cli.js
+++ b/scripts/lottery_cli.js
@@ -6,6 +6,7 @@
 //   node scripts/lottery_cli.js claim <POOL_STATE>
 //   node scripts/lottery_cli.js draw_weekly <POOL_STATE>
 //   node scripts/lottery_cli.js tx_with_fee <POOL_STATE> <FROM_OWNER> <TO_OWNER> <MINT_2022> <AMOUNT> <FEE_BPS>
+//       (отправителем может быть только локальный кошелёк)
 
 const anchor = require("@coral-xyz/anchor");
 const { PublicKey, SystemProgram } = require("@solana/web3.js");
@@ -266,9 +267,9 @@ async function main() {
 
     const { vaultTokenAccount } = deriveVault(program.programId, pool);
 
-    // MVP: отправителем выступает локальный кошелёк
+    // Отправителем может быть только локальный кошелёк
     if (!fromOwner.equals(wallet.publicKey)) {
-      throw new Error("Sender must equal local wallet in this CLI MVP");
+      throw new Error("Sender must be the local wallet");
     }
 
     // ATA для from/to (Token-2022)

--- a/scripts/lottery_cli.js
+++ b/scripts/lottery_cli.js
@@ -10,268 +10,303 @@
 const anchor = require("@coral-xyz/anchor");
 const { PublicKey, SystemProgram } = require("@solana/web3.js");
 const {
-    TOKEN_2022_PROGRAM_ID,
-    ASSOCIATED_TOKEN_PROGRAM_ID,
-    getAssociatedTokenAddressSync,
-    createAssociatedTokenAccountInstruction,
+  TOKEN_2022_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddressSync,
+  createAssociatedTokenAccountInstruction,
 } = require("@solana/spl-token");
 const fs = require("fs");
 const path = require("path");
 
 async function loadProgram(provider) {
-    try {
-        const p = anchor.workspace.SolLottery;
-        if (p) return p;
-    } catch {}
-    const idlPath = path.resolve("target/idl/sol_lottery.json");
-    const idl = JSON.parse(fs.readFileSync(idlPath, "utf8"));
-    const programId = new PublicKey(idl.metadata?.address || process.env.PROGRAM_ID);
-    if (!programId) throw new Error("No programId: set idl.metadata.address or PROGRAM_ID env");
-    return new anchor.Program(idl, programId, provider);
+  try {
+    const p = anchor.workspace.SolLottery;
+    if (p) return p;
+  } catch {}
+  const idlPath = path.resolve("target/idl/sol_lottery.json");
+  const idl = JSON.parse(fs.readFileSync(idlPath, "utf8"));
+  const programId = new PublicKey(
+    idl.metadata?.address || process.env.PROGRAM_ID
+  );
+  if (!programId)
+    throw new Error("No programId: set idl.metadata.address or PROGRAM_ID env");
+  return new anchor.Program(idl, programId, provider);
 }
 
 function deriveVault(programId, pool) {
-    const [vaultAuthority] = PublicKey.findProgramAddressSync(
-        [Buffer.from("vault"), pool.toBuffer()],
-        programId
-    );
-    const [vaultTokenAccount] = PublicKey.findProgramAddressSync(
-        [Buffer.from("vault"), pool.toBuffer()],
-        programId
-    );
-    return { vaultAuthority, vaultTokenAccount };
+  const [vaultAuthority] = PublicKey.findProgramAddressSync(
+    [Buffer.from("vault-auth"), pool.toBuffer()],
+    programId
+  );
+  const [vaultTokenAccount] = PublicKey.findProgramAddressSync(
+    [Buffer.from("vault"), pool.toBuffer()],
+    programId
+  );
+  return { vaultAuthority, vaultTokenAccount };
 }
 
 function deriveStaking(programId, pool) {
-    const [stakingAuthority] = PublicKey.findProgramAddressSync(
-        [Buffer.from("staking"), pool.toBuffer()],
-        programId
-    );
-    const [stakingTokenAccount] = PublicKey.findProgramAddressSync(
-        [Buffer.from("staking"), pool.toBuffer()],
-        programId
-    );
-    return { stakingAuthority, stakingTokenAccount };
+  const [stakingAuthority] = PublicKey.findProgramAddressSync(
+    [Buffer.from("staking-auth"), pool.toBuffer()],
+    programId
+  );
+  const [stakingTokenAccount] = PublicKey.findProgramAddressSync(
+    [Buffer.from("staking"), pool.toBuffer()],
+    programId
+  );
+  return { stakingAuthority, stakingTokenAccount };
 }
 
 // Создание/проверка ATA под Token-2022
-async function ensureAtaIx(connection, mint, owner, payer, allowOwnerOffCurve = false) {
-    const ata = getAssociatedTokenAddressSync(
-        mint,
-        owner,
-        allowOwnerOffCurve,             // PDA -> true, обычный owner -> false
-        TOKEN_2022_PROGRAM_ID,
-        ASSOCIATED_TOKEN_PROGRAM_ID
-    );
-    const info = await connection.getAccountInfo(ata);
-    if (info) return { ata, ix: null };
-    const ix = createAssociatedTokenAccountInstruction(
-        payer,
-        ata,
-        owner,
-        mint,
-        TOKEN_2022_PROGRAM_ID,
-        ASSOCIATED_TOKEN_PROGRAM_ID
-    );
-    return { ata, ix };
+async function ensureAtaIx(
+  connection,
+  mint,
+  owner,
+  payer,
+  allowOwnerOffCurve = false
+) {
+  const ata = getAssociatedTokenAddressSync(
+    mint,
+    owner,
+    allowOwnerOffCurve, // PDA -> true, обычный owner -> false
+    TOKEN_2022_PROGRAM_ID,
+    ASSOCIATED_TOKEN_PROGRAM_ID
+  );
+  const info = await connection.getAccountInfo(ata);
+  if (info) return { ata, ix: null };
+  const ix = createAssociatedTokenAccountInstruction(
+    payer,
+    ata,
+    owner,
+    mint,
+    TOKEN_2022_PROGRAM_ID,
+    ASSOCIATED_TOKEN_PROGRAM_ID
+  );
+  return { ata, ix };
 }
 
 async function main() {
-    const [, , cmd, ...args] = process.argv;
-    if (!cmd) {
-        console.log("usage: node scripts/lottery_cli.js <cmd> ...");
-        process.exit(1);
+  const [, , cmd, ...args] = process.argv;
+  if (!cmd) {
+    console.log("usage: node scripts/lottery_cli.js <cmd> ...");
+    process.exit(1);
+  }
+
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+  const program = await loadProgram(provider);
+  const connection = provider.connection;
+  const wallet = provider.wallet.payer; // Keypair (локальный)
+
+  if (cmd === "status") {
+    const [poolStr] = args;
+    const pool = new PublicKey(poolStr);
+    const state = await program.account.poolState.fetch(pool);
+    console.log({
+      owner: state.owner.toBase58(),
+      mint: state.mint.toBase58(),
+      vaultBump: state.vaultBump,
+      stakingBump: state.stakingBump,
+      totalStaked: state.totalStaked.toString(),
+      accRps: state.accRewardPerShare.toString(),
+      lastDrawTs: state.lastDrawTs.toString(),
+      drawInterval: state.drawInterval.toString(),
+      vaultAccounted: state.vaultAccounted.toString(),
+    });
+    return;
+  }
+
+  if (cmd === "stake" || cmd === "unstake") {
+    const [poolStr, mintStr, amountStr] = args;
+    const pool = new PublicKey(poolStr);
+    const mint = new PublicKey(mintStr);
+    const amount = new anchor.BN(amountStr);
+
+    const { vaultAuthority, vaultTokenAccount } = deriveVault(
+      program.programId,
+      pool
+    );
+    const { stakingAuthority, stakingTokenAccount } = deriveStaking(
+      program.programId,
+      pool
+    );
+
+    const user = wallet.publicKey;
+
+    // ATA пользователя под Token-2022
+    const { ata: userAta, ix } = await ensureAtaIx(
+      connection,
+      mint,
+      user,
+      user
+    );
+
+    const [userStakePda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("user"), pool.toBuffer(), user.toBuffer()],
+      program.programId
+    );
+
+    const tx = new anchor.web3.Transaction();
+    if (ix) tx.add(ix);
+
+    const method =
+      cmd === "stake"
+        ? program.methods.stake(amount)
+        : program.methods.unstake(amount);
+    const sig = await method
+      .accounts({
+        poolState: pool,
+        mint,
+        vaultTokenAccount,
+        vaultAuthority,
+        stakingTokenAccount,
+        stakingAuthority,
+        userStake: userStakePda,
+        user,
+        userTokenAccount: userAta,
+        tokenProgram: TOKEN_2022_PROGRAM_ID,
+        systemProgram: SystemProgram.programId,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      })
+      .preInstructions(tx.instructions)
+      .rpc();
+
+    console.log(`${cmd} tx:`, sig);
+    return;
+  }
+
+  if (cmd === "claim") {
+    const [poolStr] = args;
+    const pool = new PublicKey(poolStr);
+    const state = await program.account.poolState.fetch(pool);
+    const mint = state.mint;
+
+    const { vaultAuthority, vaultTokenAccount } = deriveVault(
+      program.programId,
+      pool
+    );
+
+    const user = wallet.publicKey;
+    const { ata: userAta, ix } = await ensureAtaIx(
+      connection,
+      mint,
+      user,
+      user
+    );
+
+    const [userStakePda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("user"), pool.toBuffer(), user.toBuffer()],
+      program.programId
+    );
+
+    const tx = new anchor.web3.Transaction();
+    if (ix) tx.add(ix);
+
+    const sig = await program.methods
+      .claim()
+      .accounts({
+        poolState: pool,
+        vaultTokenAccount,
+        vaultAuthority,
+        userStake: userStakePda,
+        user,
+        userTokenAccount: userAta,
+        tokenProgram: TOKEN_2022_PROGRAM_ID,
+      })
+      .preInstructions(tx.instructions)
+      .rpc();
+
+    console.log("claim tx:", sig);
+    return;
+  }
+
+  if (cmd === "draw_weekly") {
+    const [poolStr] = args;
+    const pool = new PublicKey(poolStr);
+    const state = await program.account.poolState.fetch(pool);
+
+    const { vaultAuthority, vaultTokenAccount } = deriveVault(
+      program.programId,
+      pool
+    );
+
+    // ATA владельца пула (создателя)
+    const ownerAta = getAssociatedTokenAddressSync(
+      state.mint,
+      state.owner,
+      false,
+      TOKEN_2022_PROGRAM_ID,
+      ASSOCIATED_TOKEN_PROGRAM_ID
+    );
+
+    const sig = await program.methods
+      .drawWeekly()
+      .accounts({
+        poolState: pool,
+        vaultTokenAccount,
+        vaultAuthority,
+        ownerTokenAccount: ownerAta,
+        tokenProgram: TOKEN_2022_PROGRAM_ID,
+      })
+      .rpc();
+
+    console.log("draw_weekly tx:", sig);
+    return;
+  }
+
+  if (cmd === "tx_with_fee") {
+    const [poolStr, fromOwnerStr, toOwnerStr, mintStr, amountStr, feeBpsStr] =
+      args;
+    const pool = new PublicKey(poolStr);
+    const fromOwner = new PublicKey(fromOwnerStr);
+    const toOwner = new PublicKey(toOwnerStr);
+    const mint = new PublicKey(mintStr);
+    const amount = new anchor.BN(amountStr);
+    const feeBps = new anchor.BN(feeBpsStr); // параметр для твоей MVP-инструкции
+
+    const { vaultTokenAccount } = deriveVault(program.programId, pool);
+
+    // MVP: отправителем выступает локальный кошелёк
+    if (!fromOwner.equals(wallet.publicKey)) {
+      throw new Error("Sender must equal local wallet in this CLI MVP");
     }
 
-    const provider = anchor.AnchorProvider.env();
-    anchor.setProvider(provider);
-    const program = await loadProgram(provider);
-    const connection = provider.connection;
-    const wallet = provider.wallet.payer; // Keypair (локальный)
+    // ATA для from/to (Token-2022)
+    const fromAta = getAssociatedTokenAddressSync(
+      mint,
+      fromOwner,
+      false,
+      TOKEN_2022_PROGRAM_ID,
+      ASSOCIATED_TOKEN_PROGRAM_ID
+    );
+    const toAta = getAssociatedTokenAddressSync(
+      mint,
+      toOwner,
+      false,
+      TOKEN_2022_PROGRAM_ID,
+      ASSOCIATED_TOKEN_PROGRAM_ID
+    );
 
-    if (cmd === "status") {
-        const [poolStr] = args;
-        const pool = new PublicKey(poolStr);
-        const state = await program.account.poolState.fetch(pool);
-        console.log({
-            owner: state.owner.toBase58(),
-            mint: state.mint.toBase58(),
-            vaultBump: state.vaultBump,
-            stakingBump: state.stakingBump,
-            totalStaked: state.totalStaked.toString(),
-            accRps: state.accRewardPerShare.toString(),
-            lastDrawTs: state.lastDrawTs.toString(),
-            drawInterval: state.drawInterval.toString(),
-            vaultAccounted: state.vaultAccounted.toString(),
-        });
-        return;
-    }
+    const sig = await program.methods
+      .transferWithFee(amount, feeBps) // твоя on-chain MVP-логика (не Token-2022)
+      .accounts({
+        from: fromAta,
+        to: toAta,
+        vaultTokenAccount,
+        sender: wallet.publicKey,
+        tokenProgram: TOKEN_2022_PROGRAM_ID,
+      })
+      .rpc();
 
-    if (cmd === "stake" || cmd === "unstake") {
-        const [poolStr, mintStr, amountStr] = args;
-        const pool = new PublicKey(poolStr);
-        const mint = new PublicKey(mintStr);
-        const amount = new anchor.BN(amountStr);
+    console.log("tx_with_fee tx:", sig);
+    return;
+  }
 
-        const { vaultAuthority, vaultTokenAccount } = deriveVault(program.programId, pool);
-        const { stakingAuthority, stakingTokenAccount } = deriveStaking(program.programId, pool);
-
-        const user = wallet.publicKey;
-
-        // ATA пользователя под Token-2022
-        const { ata: userAta, ix } = await ensureAtaIx(connection, mint, user, user);
-
-        const [userStakePda] = PublicKey.findProgramAddressSync(
-            [Buffer.from("user"), pool.toBuffer(), user.toBuffer()],
-            program.programId
-        );
-
-        const tx = new anchor.web3.Transaction();
-        if (ix) tx.add(ix);
-
-        const method = cmd === "stake" ? program.methods.stake(amount) : program.methods.unstake(amount);
-        const sig = await method
-            .accounts({
-                poolState: pool,
-                mint,
-                vaultTokenAccount,
-                vaultAuthority,
-                stakingTokenAccount,
-                stakingAuthority,
-                userStake: userStakePda,
-                user,
-                userTokenAccount: userAta,
-                tokenProgram: TOKEN_2022_PROGRAM_ID,
-                systemProgram: SystemProgram.programId,
-                rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-            })
-            .preInstructions(tx.instructions)
-            .rpc();
-
-        console.log(`${cmd} tx:`, sig);
-        return;
-    }
-
-    if (cmd === "claim") {
-        const [poolStr] = args;
-        const pool = new PublicKey(poolStr);
-        const state = await program.account.poolState.fetch(pool);
-        const mint = state.mint;
-
-        const { vaultAuthority, vaultTokenAccount } = deriveVault(program.programId, pool);
-
-        const user = wallet.publicKey;
-        const { ata: userAta, ix } = await ensureAtaIx(connection, mint, user, user);
-
-        const [userStakePda] = PublicKey.findProgramAddressSync(
-            [Buffer.from("user"), pool.toBuffer(), user.toBuffer()],
-            program.programId
-        );
-
-        const tx = new anchor.web3.Transaction();
-        if (ix) tx.add(ix);
-
-        const sig = await program.methods
-            .claim()
-            .accounts({
-                poolState: pool,
-                vaultTokenAccount,
-                vaultAuthority,
-                userStake: userStakePda,
-                user,
-                userTokenAccount: userAta,
-                tokenProgram: TOKEN_2022_PROGRAM_ID,
-            })
-            .preInstructions(tx.instructions)
-            .rpc();
-
-        console.log("claim tx:", sig);
-        return;
-    }
-
-    if (cmd === "draw_weekly") {
-        const [poolStr] = args;
-        const pool = new PublicKey(poolStr);
-        const state = await program.account.poolState.fetch(pool);
-
-        const { vaultAuthority, vaultTokenAccount } = deriveVault(program.programId, pool);
-
-        // ATA владельца пула (создателя)
-        const ownerAta = getAssociatedTokenAddressSync(
-            state.mint,
-            state.owner,
-            false,
-            TOKEN_2022_PROGRAM_ID,
-            ASSOCIATED_TOKEN_PROGRAM_ID
-        );
-
-        const sig = await program.methods
-            .drawWeekly()
-            .accounts({
-                poolState: pool,
-                vaultTokenAccount,
-                vaultAuthority,
-                ownerTokenAccount: ownerAta,
-                tokenProgram: TOKEN_2022_PROGRAM_ID,
-            })
-            .rpc();
-
-        console.log("draw_weekly tx:", sig);
-        return;
-    }
-
-    if (cmd === "tx_with_fee") {
-        const [poolStr, fromOwnerStr, toOwnerStr, mintStr, amountStr, feeBpsStr] = args;
-        const pool = new PublicKey(poolStr);
-        const fromOwner = new PublicKey(fromOwnerStr);
-        const toOwner = new PublicKey(toOwnerStr);
-        const mint = new PublicKey(mintStr);
-        const amount = new anchor.BN(amountStr);
-        const feeBps = new anchor.BN(feeBpsStr); // параметр для твоей MVP-инструкции
-
-        const { vaultTokenAccount } = deriveVault(program.programId, pool);
-
-        // MVP: отправителем выступает локальный кошелёк
-        if (!fromOwner.equals(wallet.publicKey)) {
-            throw new Error("Sender must equal local wallet in this CLI MVP");
-        }
-
-        // ATA для from/to (Token-2022)
-        const fromAta = getAssociatedTokenAddressSync(
-            mint,
-            fromOwner,
-            false,
-            TOKEN_2022_PROGRAM_ID,
-            ASSOCIATED_TOKEN_PROGRAM_ID
-        );
-        const toAta = getAssociatedTokenAddressSync(
-            mint,
-            toOwner,
-            false,
-            TOKEN_2022_PROGRAM_ID,
-            ASSOCIATED_TOKEN_PROGRAM_ID
-        );
-
-        const sig = await program.methods
-            .transferWithFee(amount, feeBps) // твоя on-chain MVP-логика (не Token-2022)
-            .accounts({
-                from: fromAta,
-                to: toAta,
-                vaultTokenAccount,
-                sender: wallet.publicKey,
-                tokenProgram: TOKEN_2022_PROGRAM_ID,
-            })
-            .rpc();
-
-        console.log("tx_with_fee tx:", sig);
-        return;
-    }
-
-    console.log("Unknown command");
+  console.log("Unknown command");
 }
 
 main().catch((e) => {
-    console.error("CLI ERROR:", e.message);
-    console.error(e);
-    process.exit(1);
+  console.error("CLI ERROR:", e.message);
+  console.error(e);
+  process.exit(1);
 });

--- a/scripts/t22_transfer.js
+++ b/scripts/t22_transfer.js
@@ -6,71 +6,92 @@
 
 const { Connection, Keypair, PublicKey } = require("@solana/web3.js");
 const {
-    TOKEN_2022_PROGRAM_ID,
-    ASSOCIATED_TOKEN_PROGRAM_ID,
-    getAssociatedTokenAddressSync,
-    getMint,
-    createAssociatedTokenAccountInstruction,
-    transferChecked,
+  TOKEN_2022_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddressSync,
+  getMint,
+  createAssociatedTokenAccountInstruction,
+  transferChecked,
 } = require("@solana/spl-token");
 const fs = require("fs");
 
 (async () => {
-    try {
-        const [MINT, DEST, AMOUNT_RAW] = process.argv.slice(2);
-        if (!MINT || !DEST || !AMOUNT_RAW) {
-            throw new Error("Usage: node scripts/t22_transfer.js <MINT_2022> <DEST_PUBKEY> <AMOUNT_RAW>");
-        }
-        const url = process.env.ANCHOR_PROVIDER_URL || "https://api.devnet.solana.com";
-        const connection = new Connection(url, "confirmed");
-        const walletPath = process.env.ANCHOR_WALLET || (process.env.HOME + "/.config/solana/id.json");
-        const payer = Keypair.fromSecretKey(Uint8Array.from(JSON.parse(fs.readFileSync(walletPath, "utf8"))));
-
-        const mintPk = new PublicKey(MINT);
-        const destPk = new PublicKey(DEST);
-
-        const srcAta = getAssociatedTokenAddressSync(mintPk, payer.publicKey, false, TOKEN_2022_PROGRAM_ID);
-        const dstAta = getAssociatedTokenAddressSync(mintPk, destPk, false, TOKEN_2022_PROGRAM_ID);
-
-        const ixes = [];
-        const ai = await connection.getAccountInfo(dstAta);
-        if (!ai) {
-            ixes.push(
-                createAssociatedTokenAccountInstruction(
-                    payer.publicKey,
-                    dstAta,
-                    destPk,
-                    mintPk,
-                    TOKEN_2022_PROGRAM_ID,
-                    ASSOCIATED_TOKEN_PROGRAM_ID
-                )
-            );
-        }
-
-        const mintInfo = await getMint(connection, mintPk, "confirmed", TOKEN_2022_PROGRAM_ID);
-        const decimals = mintInfo.decimals;
-        const amount = Number(AMOUNT_RAW);
-
-        const sig = await transferChecked(
-            connection,
-            payer,
-            srcAta,
-            mintPk,
-            dstAta,
-            payer.publicKey,
-            amount,
-            decimals,
-            undefined,
-            undefined,
-            TOKEN_2022_PROGRAM_ID,
-            { preflightCommitment: "confirmed" },
-            ixes
-        );
-
-        console.log("transfer tx:", sig);
-    } catch (e) {
-        console.error("T22 TRANSFER ERROR:", e.message);
-        console.error(e);
-        process.exit(1);
+  try {
+    const [MINT, DEST, AMOUNT_RAW] = process.argv.slice(2);
+    if (!MINT || !DEST || !AMOUNT_RAW) {
+      throw new Error(
+        "Usage: node scripts/t22_transfer.js <MINT_2022> <DEST_PUBKEY> <AMOUNT_RAW>"
+      );
     }
+    const url =
+      process.env.ANCHOR_PROVIDER_URL || "https://api.devnet.solana.com";
+    const connection = new Connection(url, "confirmed");
+    const walletPath =
+      process.env.ANCHOR_WALLET || process.env.HOME + "/.config/solana/id.json";
+    const payer = Keypair.fromSecretKey(
+      Uint8Array.from(JSON.parse(fs.readFileSync(walletPath, "utf8")))
+    );
+
+    const mintPk = new PublicKey(MINT);
+    const destPk = new PublicKey(DEST);
+
+    const srcAta = getAssociatedTokenAddressSync(
+      mintPk,
+      payer.publicKey,
+      false,
+      TOKEN_2022_PROGRAM_ID
+    );
+    const dstAta = getAssociatedTokenAddressSync(
+      mintPk,
+      destPk,
+      false,
+      TOKEN_2022_PROGRAM_ID
+    );
+
+    const ixes = [];
+    const ai = await connection.getAccountInfo(dstAta);
+    if (!ai) {
+      ixes.push(
+        createAssociatedTokenAccountInstruction(
+          payer.publicKey,
+          dstAta,
+          destPk,
+          mintPk,
+          TOKEN_2022_PROGRAM_ID,
+          ASSOCIATED_TOKEN_PROGRAM_ID
+        )
+      );
+    }
+
+    const mintInfo = await getMint(
+      connection,
+      mintPk,
+      "confirmed",
+      TOKEN_2022_PROGRAM_ID
+    );
+    const decimals = mintInfo.decimals;
+    const amount = Number(AMOUNT_RAW);
+
+    const sig = await transferChecked(
+      connection,
+      payer,
+      srcAta,
+      mintPk,
+      dstAta,
+      payer.publicKey,
+      amount,
+      decimals,
+      undefined,
+      undefined,
+      TOKEN_2022_PROGRAM_ID,
+      { preflightCommitment: "confirmed" },
+      ixes
+    );
+
+    console.log("transfer tx:", sig);
+  } catch (e) {
+    console.error("T22 TRANSFER ERROR:", e.message);
+    console.error(e);
+    process.exit(1);
+  }
 })();

--- a/scripts/t22_withdraw_from_accounts.js
+++ b/scripts/t22_withdraw_from_accounts.js
@@ -6,64 +6,68 @@
 
 const { Connection, Keypair, PublicKey } = require("@solana/web3.js");
 const {
-    TOKEN_2022_PROGRAM_ID,
-    unpackAccount,
-    getTransferFeeAmount,
-    withdrawWithheldTokensFromAccounts,
+  TOKEN_2022_PROGRAM_ID,
+  unpackAccount,
+  getTransferFeeAmount,
+  withdrawWithheldTokensFromAccounts,
 } = require("@solana/spl-token");
 const fs = require("fs");
 
 (async () => {
-    try {
-        const [MINT, VAULT_ATA, ...ACCTS] = process.argv.slice(2);
-        if (!MINT || !VAULT_ATA || ACCTS.length === 0) {
-            throw new Error("Usage: node scripts/t22_withdraw_from_accounts.js <MINT_2022> <VAULT_ATA> <ACCOUNT_1> [...]");
-        }
-
-        const url = process.env.ANCHOR_PROVIDER_URL || "https://api.devnet.solana.com";
-        const connection = new Connection(url, "confirmed");
-
-        const walletPath = process.env.ANCHOR_WALLET || (process.env.HOME + "/.config/solana/id.json");
-        const secret = JSON.parse(fs.readFileSync(walletPath, "utf8"));
-        const payer = Keypair.fromSecretKey(Uint8Array.from(secret));
-
-        const mint = new PublicKey(MINT);
-        const vaultAta = new PublicKey(VAULT_ATA);
-
-        // отберём только аккаунты, где реально есть withheld
-        const list = [];
-        for (const a of ACCTS) {
-            const pk = new PublicKey(a);
-            const ai = await connection.getAccountInfo(pk, "confirmed");
-            if (!ai) continue;
-            try {
-                const acc = unpackAccount(pk, ai, TOKEN_2022_PROGRAM_ID);
-                const tfa = getTransferFeeAmount(acc);
-                if (tfa && tfa.withheldAmount > 0n) list.push(pk);
-            } catch {}
-        }
-
-        if (list.length === 0) {
-            console.log("Нет аккаунтов с удержанными комиссиями");
-            return;
-        }
-
-        const sig = await withdrawWithheldTokensFromAccounts(
-            connection,
-            payer,
-            mint,
-            vaultAta,
-            payer,
-            undefined,           // multiSigners
-            list,
-            undefined,           // confirmOptions
-            TOKEN_2022_PROGRAM_ID
-        );
-
-        console.log("withdraw-withheld-from-accounts tx:", sig);
-    } catch (e) {
-        console.error("WITHDRAW ERROR:", e.message);
-        console.error(e);
-        process.exit(1);
+  try {
+    const [MINT, VAULT_ATA, ...ACCTS] = process.argv.slice(2);
+    if (!MINT || !VAULT_ATA || ACCTS.length === 0) {
+      throw new Error(
+        "Usage: node scripts/t22_withdraw_from_accounts.js <MINT_2022> <VAULT_ATA> <ACCOUNT_1> [...]"
+      );
     }
+
+    const url =
+      process.env.ANCHOR_PROVIDER_URL || "https://api.devnet.solana.com";
+    const connection = new Connection(url, "confirmed");
+
+    const walletPath =
+      process.env.ANCHOR_WALLET || process.env.HOME + "/.config/solana/id.json";
+    const secret = JSON.parse(fs.readFileSync(walletPath, "utf8"));
+    const payer = Keypair.fromSecretKey(Uint8Array.from(secret));
+
+    const mint = new PublicKey(MINT);
+    const vaultAta = new PublicKey(VAULT_ATA);
+
+    // отберём только аккаунты, где реально есть withheld
+    const list = [];
+    for (const a of ACCTS) {
+      const pk = new PublicKey(a);
+      const ai = await connection.getAccountInfo(pk, "confirmed");
+      if (!ai) continue;
+      try {
+        const acc = unpackAccount(pk, ai, TOKEN_2022_PROGRAM_ID);
+        const tfa = getTransferFeeAmount(acc);
+        if (tfa && tfa.withheldAmount > 0n) list.push(pk);
+      } catch {}
+    }
+
+    if (list.length === 0) {
+      console.log("Нет аккаунтов с удержанными комиссиями");
+      return;
+    }
+
+    const sig = await withdrawWithheldTokensFromAccounts(
+      connection,
+      payer,
+      mint,
+      vaultAta,
+      payer,
+      undefined, // multiSigners
+      list,
+      undefined, // confirmOptions
+      TOKEN_2022_PROGRAM_ID
+    );
+
+    console.log("withdraw-withheld-from-accounts tx:", sig);
+  } catch (e) {
+    console.error("WITHDRAW ERROR:", e.message);
+    console.error(e);
+    process.exit(1);
+  }
 })();

--- a/tests/sol_lottery.js
+++ b/tests/sol_lottery.js
@@ -1,13 +1,80 @@
 const anchor = require("@coral-xyz/anchor");
+const { TOKEN_2022_PROGRAM_ID, createMint } = require("@solana/spl-token");
+const { assert } = require("chai");
 
 describe("sol_lottery", () => {
   // Configure the client to use the local cluster.
-  anchor.setProvider(anchor.AnchorProvider.env());
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
 
   it("Is initialized!", async () => {
-    // Add your test here.
     const program = anchor.workspace.solLottery;
-    const tx = await program.methods.initialize().rpc();
-    console.log("Your transaction signature", tx);
+    const drawIntervalSecs = 60;
+
+    // Account that will hold pool state data
+    const poolState = anchor.web3.Keypair.generate();
+
+    // Create mint that will be used by the pool
+    const mint = await createMint(
+      provider.connection,
+      provider.wallet.payer,
+      provider.wallet.publicKey,
+      null,
+      6,
+      undefined,
+      undefined,
+      TOKEN_2022_PROGRAM_ID
+    );
+
+    // Derive PDA for vault token account and its authority
+    const [vaultTokenAccount, _vaultBump] =
+      anchor.web3.PublicKey.findProgramAddressSync(
+        [Buffer.from("vault"), poolState.publicKey.toBuffer()],
+        program.programId
+      );
+    const [vaultAuthority, _vaultAuthBump] =
+      anchor.web3.PublicKey.findProgramAddressSync(
+        [Buffer.from("vault-auth"), poolState.publicKey.toBuffer()],
+        program.programId
+      );
+
+    // Derive PDA for staking token account and its authority
+    const [stakingTokenAccount, _stakingBump] =
+      anchor.web3.PublicKey.findProgramAddressSync(
+        [Buffer.from("staking"), poolState.publicKey.toBuffer()],
+        program.programId
+      );
+    const [stakingAuthority, _stakingAuthBump] =
+      anchor.web3.PublicKey.findProgramAddressSync(
+        [Buffer.from("staking-auth"), poolState.publicKey.toBuffer()],
+        program.programId
+      );
+
+    // Initialize the pool
+    await program.methods
+      .initialize(new anchor.BN(drawIntervalSecs))
+      .accounts({
+        poolState: poolState.publicKey,
+        mint,
+        vaultTokenAccount,
+        vaultAuthority,
+        stakingTokenAccount,
+        stakingAuthority,
+        owner: provider.wallet.publicKey,
+        systemProgram: anchor.web3.SystemProgram.programId,
+        tokenProgram: TOKEN_2022_PROGRAM_ID,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      })
+      .signers([poolState])
+      .rpc();
+
+    const state = await program.account.poolState.fetch(poolState.publicKey);
+
+    assert.strictEqual(
+      state.owner.toString(),
+      provider.wallet.publicKey.toString()
+    );
+    assert.strictEqual(state.mint.toString(), mint.toString());
+    assert.strictEqual(state.drawInterval.toNumber(), drawIntervalSecs);
   });
 });


### PR DESCRIPTION
## Summary
- give vault and staking token accounts distinct authority PDAs
- adjust helper seed functions accordingly
- update CLI scripts to derive new PDAs

## Testing
- `cargo test --manifest-path programs/sol_lottery/Cargo.toml`
- `npm run lint` *(fails: Code style issues found in scripts/t22_transfer.js, scripts/t22_withdraw_from_accounts.js)*

------
https://chatgpt.com/codex/tasks/task_e_689f4dc31e7c83269781ba373c8014ff